### PR TITLE
Check if input file is empty

### DIFF
--- a/asc-to-gif.sh
+++ b/asc-to-gif.sh
@@ -14,6 +14,12 @@ if [ ! -f ${asc_filename} ]; then
     exit 1
 fi
 
+# Check if file is empty
+if [ ! -s ${asc_filename} ]; then
+    echo "Error: ${asc_filename} is empty"
+    exit 1
+fi
+
 # Settings
 gif_filename=$2
 gif_delay=100


### PR DESCRIPTION
If the input file is empty, the error messages are a bit confusing to what the issue is, e.g.:

```
./asc-to-gif.sh: line 34: test.split*: No such file or directory
rm: cannot remove 'test.split*': No such file or directory
ERROR: unable to open image `test.split*': No such file or directory @ error/blob.c/OpenBlob/2924
convert-im6.q16: unable to open image `test.split*': No such file or directory @ error/blob.c/OpenBlob/2924.
convert-im6.q16: no decode delegate for this image format `' @ error/constitute.c/ReadImage/575.
convert-im6.q16: no images defined `test.gif' @ error/convert.c/ConvertImageCommand/3229.
Generated: test.gif
rm: cannot remove 'test.split*': No such file or directory
```

I thought it would be helpful to check if the input file is empty and return an error message and exit if it is.